### PR TITLE
Item Bugs

### DIFF
--- a/include/gui/gui_manager.h
+++ b/include/gui/gui_manager.h
@@ -57,6 +57,7 @@ public:
      * @return Pointer to QDockWidget. Null if nothing has been removed.
      */
     QWidget* removeWidget(QString const& name);
+
     /**
      * @brief Adds a widget to the mainwindow.
      * @param widget pointer to the widget, action that are already within a Toolbar or MenuBar are also registered whe
@@ -65,8 +66,11 @@ public:
      * @param type what type of widget it is. Note that if a widget with a type that occurs only once
      * (CentralWidget, MenuBar, StatusBar) is added, the old widget will be deleted.
      * @return true if the widget could be added
+     *
+     * Takes the ownership of the passed window
      */
     bool addWidget(QWidget* widget, QString const& name, WidgetArea area, WidgetType type = WidgetType::DockWidget);
+
     /**
      * @brief Adds a widget to the mainwindow. \n Uses the objectName or className as name. \n
      * Appends a number if a a widget is already stored with that name
@@ -75,8 +79,11 @@ public:
      * @param type what type of widget it is. Note that if a widget with a type that occurs only once
      * (CentralWidget, MenuBar, StatusBar) is added, the old widget will be deleted.
      * @return name under which the widget was added, is empty when the widget couldn't be added
+     *
+     * * Takes the ownership of the passed window
      */
     QString addWidget(QWidget* widget, WidgetArea area, WidgetType type = WidgetType::DockWidget);
+
     /**
      * @brief moveWidget change the position of a widget
      * @param name name of the widget that should be moved
@@ -84,21 +91,25 @@ public:
      * @return true if the action was successful
      */
     bool moveWidget(QString const& name, WidgetArea area);
+
     /**
      * @brief setVisible changes the visibility of a widget
      * @param name name of the widget
      * @param visible value that the visibility is set to
      */
     void setVisible(QString const& name, bool visible);
+
     /**
      * @brief showMainWindow makes tha main window visible
      */
     void showMainWindow();
+
     /**
      * @brief widgetReference method to access the main window
      * @return  refrence to the mainwindow
      */
     QWidget* widgetReference();
+
     /**
      * @brief  adds an action a menu or a toolbar
      * @param Action The action that is added, GuiManager doesn't takes ownership, can't be NULL
@@ -108,6 +119,7 @@ public:
      * @return True when the action could be added
      */
     bool addAction(QAction* action, QString const& name, QString const& parent);
+
     /**
      * @brief Adds the action name to the action or widget parent
      * @param name Name of the action or widget, must be an action
@@ -116,6 +128,7 @@ public:
      * @return True when the action could be added to parent
      */
     bool addActionToParent(QString const& name, QString const& parent);
+
     /**
      * @brief Adds an action to a menu or a toolbar \n Uses the objectName or className as name. \n
      * Appends a number if something is already stored with that name
@@ -125,12 +138,14 @@ public:
      * @return name under which the action was added, is empty when the widget couldn't be added
      */
     QString addAction(QAction* action, QString const& parent);
+
     /**
      * @brief Access to reference of an action
      * @param name Name of the action
      * @return Reference to the action, NULL when it doesn't exist
      */
     QAction* action(QString const& name) const;
+
     /**
      * @brief Removes an action from the gui and returns it.
      * @param name name of the action
@@ -138,6 +153,7 @@ public:
      * @return removed action, NULL when name or parent doesn't exist
      */
     QAction* removeAction(QString const& name, QString const& parent = QString());
+
     /**
      * @brief This callback will be executed by an application close event.
      * If the callback returns true the close process will be continue -> shutdown application.
@@ -145,34 +161,40 @@ public:
      * @param std::function<bool> callback
      */
     void registerCloseHandler(std::function<bool()> callback);
+
     /**
      * @brief Access to the names of the parents of an registered action
      * @param name Name of the action
      * @return List of the names of all parents of name
      */
     QStringList parents(QString const& name);
+
     /**
      * @brief Access to the names of the children of an registered action or widget
      * @param name Name of the action or widget
      * @return List of the names of all children of name
      */
     QStringList children(QString const& name) const;
+
     /**
      * @brief Access to all the names of the registered actions
      * @return List containing all names of the registered actions
      */
     QStringList registeredActions()const;
+
     /**
      * @brief Access to all the names of the registered widgets
      * @return List containing all names of the registered widgets
      */
     QStringList registeredWidgets() const;
+
     /**
      * @brief registeredWidgets return all registered widgets of the given type
      * @param type Type to be returned
      * @return Names of widgets
      */
     QStringList registeredWidgets(WidgetType type) const;
+
     /**
      * @brief mainWindowIsActive
      * @return State of the main window

--- a/include/item/abstract_item.h
+++ b/include/item/abstract_item.h
@@ -371,9 +371,9 @@ signals:
 
 public slots:
     /**
-     * @brief Removes the AbstractItem and all connections from the Scene.
+     * @brief Disconnects all connections from/to the item.
      */
-    void remove();
+    void disconnectConnections();
 
 private:
     QScopedPointer<class AbstractItemPrivate> const d_ptr;

--- a/include/item/item_input.h
+++ b/include/item/item_input.h
@@ -6,6 +6,7 @@
 
 #include <QObject>
 #include <QRectF>
+#include <QScopedPointer>
 
 class AbstractItem;
 class ItemOutput;
@@ -40,6 +41,8 @@ public:
      */
     ItemInput(AbstractItem* owner, int transportType, QString const& description,
               QRectF const& shape = {0, 0, 0, 0});
+
+    virtual ~ItemInput();
 
     /**
      * @return true if this input is connected to an output, false otherwise
@@ -109,7 +112,7 @@ signals:
     void dataChanged();
 
 private:
-    ItemInputPrivate* const d_ptr;
+    QScopedPointer<ItemInputPrivate> const d_ptr;
     Q_DECLARE_PRIVATE(ItemInput)
 };
 

--- a/include/item/item_output.h
+++ b/include/item/item_output.h
@@ -43,6 +43,8 @@ public:
     ItemOutput(AbstractItem* owner, int transportType, QString const& description,
                QRectF const& shape = {0, 0, 0, 0});
 
+    virtual ~ItemOutput();
+
     /**
      * @return true if this output is connected to at least one input, false
      * otherwise
@@ -137,7 +139,7 @@ signals:
 
 private:
     Q_DECLARE_PRIVATE(ItemOutput)
-    ItemOutputPrivate* const d_ptr;
+    QScopedPointer<ItemOutputPrivate> const d_ptr;
 };
 
 #endif // ITEM_OUTPUT_H

--- a/src/gui/gui_manager.cpp
+++ b/src/gui/gui_manager.cpp
@@ -503,6 +503,8 @@ bool GuiManager::addWidget(QWidget* widget, QString const& name, WidgetArea area
         return false;
     }
 
+    widget->setParent(d->_mainWindow);
+
     switch (type) {
     case WidgetType::DockWidget: {
 

--- a/src/gui/livedoc.cpp
+++ b/src/gui/livedoc.cpp
@@ -29,6 +29,7 @@ Livedoc::Livedoc()
 
 Livedoc::~Livedoc()
 {
+    qDeleteAll(lis_providers.begin(), lis_providers.end());
 }
 
 bool Livedoc::postInit()

--- a/src/item/abstract_item.cpp
+++ b/src/item/abstract_item.cpp
@@ -452,13 +452,10 @@ QPen AbstractItem::connectorStyle(int type)
 
 void AbstractItem::disconnectConnections() {
     Q_D(AbstractItem);
-    for (int i = d->_inputs.count() - 1; i >= 0; i--) {
-        ItemInput* input = d->_inputs.at(i);
+    for(ItemInput* input : d->_inputs) {
         input->disconnectOutput();
     }
-
-    for (int i = d->_outputs.count() - 1; i >= 0; i--) {
-        ItemOutput* output = d->_outputs.at(i);
+    for(ItemOutput* output: d->_outputs) {
         output->disconnectInputs();
     }
 }
@@ -469,20 +466,22 @@ AbstractItem::~AbstractItem()
 
     bool changes = false;
 
-    for (int i = d->_inputs.count() - 1; i >= 0; i--) {
-        ItemInput* input = d->_inputs.at(i);
+    QMutableListIterator<ItemInput*> it_inp(d->_inputs);
+    while(it_inp.hasNext()) {
+        ItemInput* input = it_inp.next();
         disconnect(input,0,this,0);
         input->disconnectOutput();
-        d->_inputs.removeAt(i);
+        it_inp.remove();
         delete input;
         changes = true;
     }
 
-    for (int i = d->_outputs.count() - 1; i >= 0; i--) {
-        ItemOutput* output = d->_outputs.at(i);
+    QMutableListIterator<ItemOutput*> it_out(d->_outputs);
+    while(it_out.hasNext()) {
+        ItemOutput* output = it_out.next();
         disconnect(output,0,this,0);
         output->disconnectInputs();
-        d->_outputs.removeAt(i);
+        it_out.remove();
         delete output;
         changes = true;
     }

--- a/src/item/abstract_window_item.cpp
+++ b/src/item/abstract_window_item.cpp
@@ -145,6 +145,7 @@ void AbstractWindowItem::openWindow()
             d->_window->show();
         } else {
             d->_window->activateWindow();
+            d->_window->raise();
         }
     }
 }

--- a/src/item/abstract_window_item.cpp
+++ b/src/item/abstract_window_item.cpp
@@ -7,8 +7,8 @@
 AbstractWindowItem::AbstractWindowItem(QString const& typeName) :
     AbstractItem(typeName), d_ptr(new AbstractWindowItemPrivate(this))
 {
-    connect(this,&AbstractItem::nameChanged,this,[this](){
-        Q_D(AbstractWindowItem);
+    Q_D(AbstractWindowItem);
+    connect(this,&AbstractItem::nameChanged,this,[d](){
         d->setupWindow(); //sets the window title if window is not null
     });
 }

--- a/src/item/abstract_window_item.cpp
+++ b/src/item/abstract_window_item.cpp
@@ -7,6 +7,10 @@
 AbstractWindowItem::AbstractWindowItem(QString const& typeName) :
     AbstractItem(typeName), d_ptr(new AbstractWindowItemPrivate(this))
 {
+    connect(this,&AbstractItem::nameChanged,this,[this](){
+        Q_D(AbstractWindowItem);
+        d->setupWindow(); //sets the window title if window is not null
+    });
 }
 
 AbstractWindowItem::~AbstractWindowItem()

--- a/src/item/item_connector.cpp
+++ b/src/item/item_connector.cpp
@@ -49,7 +49,7 @@ Item_Connector::~Item_Connector()
 
 void Item_Connector::checkConnection()
 {
-    if (input->output() != output || !output->inputs().contains(input)) {
+    if (! (input->output() == output && output->inputs().contains(input))) {
         delete this;
     }
 }

--- a/src/item/item_connector.cpp
+++ b/src/item/item_connector.cpp
@@ -24,32 +24,33 @@ Item_Connector::Item_Connector(ItemOutput* output, ItemInput* input)
     i_routing_mode = 0;
     connect(input, SIGNAL(positionChanged()), this, SLOT(do_update()));
     connect(output, SIGNAL(positionChanged()), this, SLOT(do_update()));
-    connect(input, SIGNAL(outputDisconnected()), this, SLOT(pri_slot_check_connection()));
-    connect(output, SIGNAL(inputDisconnected()), this, SLOT(pri_slot_check_connection()));
+    connect(input, SIGNAL(outputDisconnected()), this, SLOT(checkConnection()));
+    connect(output, SIGNAL(inputDisconnected()), this, SLOT(checkConnection()));
     connect(output, SIGNAL(dataChanged()), this, SLOT(repaint()));
     pen = AbstractItem::connectorStyle(input->transportType());
 }
 
-
-void Item_Connector::pri_slot_check_connection()
+Item_Connector::~Item_Connector()
 {
-    if (input->output() != output || !output->inputs().contains(input)) {
-        disconnect(input, 0, this, 0);
-        disconnect(output, 0, this, 0);
+    disconnect(input, 0, this, 0);
+    disconnect(output, 0, this, 0);
 
-        prepareGeometryChange(); //this and the following lines seem to be necessary, otherwise the scene will redraw the item after deletion..
-        ppa_selpoints = ppa_line =  QPainterPath();
-
-        scene()->removeItem(this);
-        emit changed();
-        delete this;
-    }
-}
-
-void Item_Connector::remove_and_delete()
-{
     if (input->output() == output) {
         input->disconnectOutput();
+    }
+
+    prepareGeometryChange(); //this and the following lines seem to be necessary, otherwise the scene will redraw the item after deletion..
+    ppa_selpoints = ppa_line =  QPainterPath();
+
+    scene()->removeItem(this);
+    emit changed();
+}
+
+
+void Item_Connector::checkConnection()
+{
+    if (input->output() != output || !output->inputs().contains(input)) {
+        delete this;
     }
 }
 

--- a/src/item/item_connector.h
+++ b/src/item/item_connector.h
@@ -14,6 +14,7 @@ class Item_Connector : public QGraphicsObject
 
 public:
     Item_Connector(ItemOutput* output, ItemInput* input);
+    virtual ~Item_Connector();
     QRectF boundingRect() const;
     QPainterPath shape() const;
     bool contains(const QPointF& point) const;
@@ -49,11 +50,10 @@ private:
     QList<Selpoint> lis_cur_selpoints; //all current selpoints
 
 private slots:
-    void pri_slot_check_connection();
+    void checkConnection();
     void repaint();
 
 public slots:
-    void remove_and_delete();
     void do_update();
 
 signals:

--- a/src/item/item_input.cpp
+++ b/src/item/item_input.cpp
@@ -9,6 +9,10 @@ ItemInput::ItemInput(AbstractItem* owner, int type, QString const& description, 
 {
 }
 
+ItemInput::~ItemInput()
+{
+}
+
 ItemInputPrivate::ItemInputPrivate(ItemInput* parent) :
     q_ptr(parent)
 {

--- a/src/item/item_note.cpp
+++ b/src/item/item_note.cpp
@@ -34,6 +34,12 @@ ItemNote::ItemNote() : QGraphicsObject()
     connect(_textItem->document(), SIGNAL(contentsChanged()), this, SLOT(updateSize()));
 }
 
+ItemNote::~ItemNote()
+{
+    scene()->removeItem(this);
+    emit changed();
+}
+
 QVariant ItemNote::itemChange(GraphicsItemChange change, QVariant const& value)
 {
     if (change == QGraphicsItem::ItemSelectedHasChanged) {
@@ -144,12 +150,6 @@ void ItemNote::updateSize()
     emit changed();
 }
 
-void ItemNote::remove()
-{
-    emit changed();
-    scene()->removeItem(this);
-}
-
 QRectF ItemNote::boundingRect() const
 {
     return _boundingRect;
@@ -234,7 +234,7 @@ void ItemNote::contextMenuEvent(QGraphicsSceneContextMenuEvent* event)
     ungrabMouse(); //Important line! Otherwise the element will be moved after you close the context menu and draw a selection rectangle somewhere.
 
     if (sel_action == act_remove) {
-        remove();
+        delete this;
     } else if (sel_action == act_edit) {
         setSelected(true);
         startEdit();

--- a/src/item/item_note.h
+++ b/src/item/item_note.h
@@ -8,6 +8,7 @@ class ItemNote : public QGraphicsObject
     Q_OBJECT
 public:
     explicit ItemNote();
+    virtual ~ItemNote();
     QRectF boundingRect() const;
     QPainterPath shape() const;
     bool inEditMode() const;
@@ -37,8 +38,6 @@ private slots:
     void selectColor();
     void startEdit();
     void stopEdit();
-public slots:
-    void remove();
 signals:
     void changed();
 

--- a/src/item/item_output.cpp
+++ b/src/item/item_output.cpp
@@ -9,10 +9,17 @@ ItemOutput::ItemOutput(AbstractItem* owner, int type, QString const& description
 {
 }
 
+ItemOutput::~ItemOutput()
+{
+
+}
+
 ItemOutputPrivate::ItemOutputPrivate(ItemOutput* parent) :
     q_ptr(parent)
 {
 }
+
+
 
 bool ItemOutput::isConnected() const
 {

--- a/src/item/item_scene.cpp
+++ b/src/item/item_scene.cpp
@@ -462,7 +462,7 @@ void ItemScene::deleteItems(QList<QGraphicsItem*> items)
         Item_Connector* con = qobject_cast<Item_Connector*>(items.at(i)->toGraphicsObject());
 
         if (con != nullptr) {
-            con->remove_and_delete();
+            delete con;
             items.removeAt(i);
         }
     }
@@ -473,14 +473,13 @@ void ItemScene::deleteItems(QList<QGraphicsItem*> items)
         AbstractItem* it = qobject_cast<AbstractItem*>(item);
 
         if (it != nullptr) {
-            it->remove();
+            it->disconnectConnections();
             delete it;
         } else {
             ItemNote* itn = qobject_cast<ItemNote*>(item);
 
             if (itn != nullptr) {
-                itn->remove();
-                delete it;
+                delete itn;
             }
         }
     }

--- a/src/item/item_toolbox.cpp
+++ b/src/item/item_toolbox.cpp
@@ -14,7 +14,7 @@ Item_Toolbox::Item_Toolbox(QWidget* parent) :
     ui(new Ui::Graphics_Item_Toolbox)
 {
     ui->setupUi(this);
-    model = new Item_List_Model(parent);
+    model = new Item_List_Model(parent==nullptr?this:parent);
     ui->treeView->setModel(model);
 }
 

--- a/src/plugin/plugin_manager.cpp
+++ b/src/plugin/plugin_manager.cpp
@@ -44,7 +44,7 @@ public:
 //*****************************************************************************
 // class PluginManagerPrivate
 //*****************************************************************************
-PluginManagerPrivate::PluginManagerPrivate(PluginManager*)
+PluginManagerPrivate::PluginManagerPrivate(PluginManager* parent) : QObject(parent)
 {
     qDebug() << "API VERSION: " << ApiVersion;
 

--- a/src/plugin/plugin_manager_p.h
+++ b/src/plugin/plugin_manager_p.h
@@ -15,7 +15,7 @@ class PluginManagerPrivate : public QObject
 
 public:
 
-    explicit PluginManagerPrivate(PluginManager* = nullptr);
+    explicit PluginManagerPrivate(PluginManager* parent = nullptr);
 
     bool loadPlugins();
     QString const& lastError();


### PR DESCRIPTION
This MR fixes 3 bugs (#6, #7 and #17), the most critical being #6. I also fixed some Memory Leaks which I found during bugfixing.

When reviewing this, you should also review if the new cleanup strategy makes sense.

> New behaviour:
> * If item's are deleted by the user (via contextmenu or pressing delete) the inputs/output connections will be removed and the corresponding signal/slots will be fired.
> * In the item's destructor (which is only invoked directly if the project get's closed or the item has no scene) the inputs/outputs will be deleted but no signals will be fired.