### PR TITLE
Add parentScopeChanged() signal

### DIFF
--- a/include/helper/settings_scope.h
+++ b/include/helper/settings_scope.h
@@ -221,6 +221,13 @@ signals:
      */
     void scopeChanged();
 
+    /**
+     * @brief Emitted when the parent of the scope changed
+     *
+     * @param old The previous parent
+     */
+    void parentScopeChanged(SettingsScope *old);
+
 private:
     QScopedPointer<class SettingsScopePrivate> d_ptr;
     Q_DECLARE_PRIVATE(SettingsScope);

--- a/src/helper/settings_scope.cpp
+++ b/src/helper/settings_scope.cpp
@@ -166,6 +166,7 @@ void SettingsScope::setParentScope(SettingsScope* newParent)
 
     }
 
+    /*
     // TODO Notify change
     // Notify change. As we have a new parent, all settings that are not defined in this scope
     // might change. Not only the settings from new parent (and its parent and so on) will have
@@ -174,6 +175,8 @@ void SettingsScope::setParentScope(SettingsScope* newParent)
         qCritical() << QString("%1: UNIMPLEMENTED: scope '%2' reparented but no notification yet!")
                     .arg(Q_FUNC_INFO, name());
     }
+    */
+    emit parentScopeChanged(oldParent);
 }
 
 SettingsScope* SettingsScope::applicationScope()


### PR DESCRIPTION
I added a signal that gets fired when the parent scope of a SettingScope changed. This should solve most problems that struggle with the fact, that the parent scope of an item is not yet available during construction (e.g. in roviz). I saw in the comment, that you intended to do something similar, but I don't know if this will already solve the issue you mentioned, so I left the comment there.