### PR TITLE
Remove any calls to remove() before item is destructed

### DIFF
--- a/src/item/abstract_item.cpp
+++ b/src/item/abstract_item.cpp
@@ -212,7 +212,6 @@ void AbstractItem::contextMenuEvent(QGraphicsSceneContextMenuEvent* event)
     ungrabMouse(); //Important line! Otherwise the element will be moved after you close the context menu and draw a selection rectangle somewhere.
 
     if (actionSel == actionRemove) {
-        remove();
         delete this;
     } else if (actionSel == actionRename) {
         d->showRenameDialog();
@@ -484,7 +483,7 @@ void AbstractItem::remove()
 
 AbstractItem::~AbstractItem()
 {
-    remove(); //Call remove() once more, in case the item was directly deleted without calling remove first
+    remove();
 }
 
 const QImage AbstractItem::image() const

--- a/src/item/item_scene.cpp
+++ b/src/item/item_scene.cpp
@@ -473,7 +473,6 @@ void ItemScene::deleteItems(QList<QGraphicsItem*> items)
         AbstractItem* it = qobject_cast<AbstractItem*>(item);
 
         if (it != nullptr) {
-            it->remove();
             delete it;
         } else {
             ItemNote* itn = qobject_cast<ItemNote*>(item);


### PR DESCRIPTION
During `AbstractItem::remove()` all `ItemInput`/`ItemOutput` objects of the item are deleted. If an item tries to access those between their destruction and it's own destruction, you get a segfault. Also, after each call to `remove()`, the item is immediately deleted afterwards and remove is called in the destructor again anyway, so we should be able to safely remove the calls before.